### PR TITLE
Notify users when using non-existing component

### DIFF
--- a/znoyder/component.py
+++ b/znoyder/component.py
@@ -1,0 +1,35 @@
+# Copyright 2022 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+from znoyder.distro import Distro
+
+
+class Component(object):
+
+    @staticmethod
+    def get_components(**kwargs):
+        info = Distro.get_distroinfo()
+        components = info.get('components')
+
+        if kwargs.get('name'):
+            components = [component for component in components
+                          if kwargs.get('name') == component.get('name')]
+
+        return components
+
+    @staticmethod
+    def exists(component_name: str) -> bool:
+        components = [comp['name'] for comp in Component.get_components()]
+        return (component_name in components)

--- a/znoyder/distro.py
+++ b/znoyder/distro.py
@@ -1,0 +1,28 @@
+# Copyright 2022 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+from distroinfo import info as di
+
+
+class Distro(object):
+
+    INFO_FILE = 'osp.yml'
+    RDOINFO_GIT_URL = 'https://code.engineering.redhat.com/gerrit/ospinfo'
+
+    @staticmethod
+    def get_distroinfo():
+        return di.DistroInfo(info_files=Distro.INFO_FILE,
+                             cache_ttl=24*60*60,  # 1 day in seconds
+                             remote_git_info=Distro.RDOINFO_GIT_URL).get_info()

--- a/znoyder/generator.py
+++ b/znoyder/generator.py
@@ -15,14 +15,15 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 #
-
 from argparse import ArgumentParser
 from argparse import Namespace
 from copy import deepcopy
 import os.path
 from pathlib import Path
 from shutil import rmtree
+import sys
 
+from znoyder.component import Component
 from znoyder import downloader
 from znoyder.exclude_map import excluded_jobs
 from znoyder.exclude_map import excluded_jobs_by_tag
@@ -37,13 +38,13 @@ from znoyder import finder
 from znoyder import browser
 
 
-UPSTREAM_CONFIGS_DIR = 'jobs-upstream/'
-GENERATED_CONFIGS_DIR = 'jobs-generated/'
-CONFIG_PREFIX = 'cre-'
 CONFIG_EXTENSION = '.yaml'
-
+CONFIG_PREFIX = 'cre-'
 # We set it to newest
 DEFAULT_BRANCH_REGEX = '^rhos-17.*$'
+UPSTREAM_CONFIGS_DIR = 'jobs-upstream/'
+GENERATED_CONFIGS_DIR = 'jobs-generated/'
+
 
 LOG = logger.LOG
 
@@ -238,6 +239,14 @@ def main(argv=None) -> None:
         LOG.info(f'Path to Zuul configuration files: {UPSTREAM_CONFIGS_DIR}')
         directories = list_existing_osp_projects()
         templates_directory = directories.pop(0)
+
+    if not directories and args.component:
+        if not Component.exists(args.component):
+            LOG.error("no such component: {}".format(args.component))
+            LOG.info("the following components are available:\n{}".format(
+                '\n'.join([comp['name'] for comp
+                           in Component.get_components()])))
+            sys.exit(2)
 
     LOG.info('Generating new downstream configuration files...')
     LOG.info(f'Output path: {GENERATED_CONFIGS_DIR}')


### PR DESCRIPTION
Before this change, when users specified non existing component,
the application would finish without any errors.

This change makes sure users know they specified non-existing
component and also prints the available components from which
users can choose.

This change also creates classes for Component and Distro for two
reasons:
  1. Sharing code across different znoyder sub-commands
  2. They will be used in the future to modelize components
     and distros
