### PR TITLE
Zuul jobs go brrrrrrrrrrrrrrr

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -154,7 +154,7 @@ add:
             - 'dnf install -y python3-swift-tests python3-nose-1.3.7 python3-dns python3-coverage python3-mock python3-requests-mock liberasurecode-devel'
             - 'cp /usr/lib/python3.9/site-packages/swift/test/sample.conf /etc/swift/test.conf'
             - "sed -i -r 's/swift_hash_path_suffix = %SWIFT_HASH_PATH_SUFFIX%/swift_hash_path_suffix = testing/' /etc/swift/swift.conf"
-            - "sed -i '/self.assertEqual(expected_args, syslog_handler_args)/d' /root/src/code.engineering.redhat.com/swift/test/unit/common/test_utils.py"
+            - "sed -i '/self.assertEqual(expected_args, syslog_handler_args)/d' {{ zuul.project.src_dir }}/test/unit/common/test_utils.py"
     'osp-17.1':
       'osp-rpm-py39':
         branches: ^rhos-17.1-trunk-patches$
@@ -165,7 +165,7 @@ add:
             - 'dnf install -y python3-swift-tests python3-nose-1.3.7 python3-dns python3-coverage python3-mock python3-requests-mock liberasurecode-devel'
             - 'cp /usr/lib/python3.9/site-packages/swift/test/sample.conf /etc/swift/test.conf'
             - "sed -i -r 's/swift_hash_path_suffix = %SWIFT_HASH_PATH_SUFFIX%/swift_hash_path_suffix = testing/' /etc/swift/swift.conf"
-            - "sed -i '/self.assertEqual(expected_args, syslog_handler_args)/d' /root/src/code.engineering.redhat.com/swift/test/unit/common/test_utils.py"
+            - "sed -i '/self.assertEqual(expected_args, syslog_handler_args)/d' {{ zuul.project.src_dir }}/test/unit/common/test_utils.py"
 
 
 #
@@ -315,22 +315,14 @@ override:
       'osp-rpm-py39':
         vars:
           extra_commands:
-            - 'dnf install -y python3-hacking python3-testscenarios python3-stestr python3-ddt python3-oslotest python3-requests-mock'
-            - 'pip install python-zunclient'
-            - 'pip install python-monascaclient'
-            - 'pip install python-blazarclient'
-            - 'pip install vitrage'
-            - 'pip install python-vitrageclient'
+            - dnf install -y python3-ddt python3-hacking python3-monascaclient python3-testscenarios python3-stestr
+            - pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt python-blazarclient python-vitrageclient python-zunclient
     'osp-17.1':
       'osp-rpm-py39':
         vars:
           extra_commands:
-            - 'dnf install -y python3-hacking python3-testscenarios python3-stestr python3-ddt python3-oslotest python3-requests-mock'
-            - 'pip install python-zunclient'
-            - 'pip install python-monascaclient'
-            - 'pip install python-blazarclient'
-            - 'pip install vitrage'
-            - 'pip install python-vitrageclient'
+            - dnf install -y python3-ddt python3-hacking python3-monascaclient python3-testscenarios python3-stestr
+            - pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt python-blazarclient python-vitrageclient python-zunclient
 
   'horizon':
     'osp-17.0':
@@ -461,32 +453,16 @@ override:
   'nova':
     'osp-17.0':
       'osp-rpm-py39':
-        voting: false
         vars:
           extra_commands:
-            - 'dnf install -y python3-stestr python3-testscenarios'
-            - 'dnf install -y python3-requests-mock python3-ddt'
-            - 'dnf install -y python3-ironicclient python3-mock'
-            - 'dnf install -y python3-oslotest python3-osprofiler'
-            - 'dnf install -y python3-testresources'
-            - 'dnf install -y python3-pycodestyle'
-            - 'dnf install -y python3-pypowervm'
-            - 'dnf install -y python3-wsgi_intercept'
-            - 'dnf install -y python3-zvmconnector'
+            - dnf install -y python3-pycodestyle python3-ddt python3-hacking python3-ironicclient python3-mock python3-oslotest python3-osprofiler python3-requests-mock python3-stestr python3-testresources python3-testscenarios python3-wsgi_intercept
+            - pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt pypowervm zVMCloudConnector
     'osp-17.1':
       'osp-rpm-py39':
-        voting: false
         vars:
           extra_commands:
-            - 'dnf install -y python3-stestr python3-testscenarios'
-            - 'dnf install -y python3-requests-mock python3-ddt'
-            - 'dnf install -y python3-ironicclient python3-mock'
-            - 'dnf install -y python3-oslotest python3-osprofiler'
-            - 'dnf install -y python3-testresources'
-            - 'dnf install -y python3-pycodestyle'
-            - 'dnf install -y python3-pypowervm'
-            - 'dnf install -y python3-wsgi_intercept'
-            - 'dnf install -y python3-zvmconnector'
+            - dnf install -y python3-pycodestyle python3-ddt python3-hacking python3-ironicclient python3-mock python3-oslotest python3-osprofiler python3-requests-mock python3-stestr python3-testresources python3-testscenarios python3-wsgi_intercept
+            - pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt pypowervm zVMCloudConnector
 
   'openstack-barbican':
     'osp-17.0':
@@ -877,14 +853,12 @@ override:
       'osp-rpm-py39':
         vars:
           extra_commands:
-            - 'dnf install -y python3-stestr python3-testscenarios'
-            - 'dnf install -y python3-requests-mock python3-ddt'
+            - dnf install -y python3-ddt python3-requests-mock python3-stestr python3-testscenarios
     'osp-17.1':
       'osp-rpm-py39':
         vars:
           extra_commands:
-            - 'dnf install -y python3-stestr python3-testscenarios'
-            - 'dnf install -y python3-requests-mock python3-ddt'
+            - dnf install -y python3-ddt python3-requests-mock python3-stestr python3-testscenarios
 
   'python-heatclient':
     'osp-17.0':
@@ -933,22 +907,24 @@ override:
   'python-keystoneclient':
     'osp-17.0':
       'osp-tox-pep8':
-        voting: false
+        vars:
+          tox_install_bindep: false
     'osp-17.1':
       'osp-tox-pep8':
-        voting: false
+        vars:
+          tox_install_bindep: false
 
   'python-keystonemiddleware':
     'osp-17.0':
       'osp-rpm-py39':
-        voting: false
         vars:
-          allow_test_requirements_txt: true
+          extra_commands:
+            - dnf install -y python3-oslotest python3-oslo-messaging python3-requests-mock python3-stestr python3-testresources python3-webtest
     'osp-17.1':
       'osp-rpm-py39':
-        voting: false
         vars:
-          allow_test_requirements_txt: true
+          extra_commands:
+            - dnf install -y python3-oslotest python3-oslo-messaging python3-requests-mock python3-stestr python3-testresources python3-webtest
 
   'python-kuryr-lib':
     'osp-17.0':
@@ -1189,12 +1165,10 @@ override:
   'python-oslo-config':
     'osp-17.0':
       'osp-rpm-py39':
-        voting: false
         vars:
           allow_test_requirements_txt: true
     'osp-17.1':
       'osp-rpm-py39':
-        voting: false
         vars:
           allow_test_requirements_txt: true
 
@@ -1436,25 +1410,19 @@ override:
     'osp-17.0':
       'osp-rpm-py39':
         vars:
-          allow_test_requirements_txt: true
           extra_commands:
-            - 'dnf remove -y python3-pbr'
-            - 'pip install python-heatclient python-glanceclient'
-            - 'pip install python-ironicclient python-novaclient'
-            - 'pip install tripleo-common'
+            - dnf install -y python3-mock python3-oslotest python3-stestr
       'osp-tox-pep8':
-        voting: false
+        vars:
+          tox_install_bindep: false
     'osp-17.1':
       'osp-rpm-py39':
         vars:
-          allow_test_requirements_txt: true
           extra_commands:
-            - 'dnf remove -y python3-pbr'
-            - 'pip install python-heatclient python-glanceclient'
-            - 'pip install python-ironicclient python-novaclient'
-            - 'pip install tripleo-common'
+            - dnf install -y python3-mock python3-oslotest python3-stestr
       'osp-tox-pep8':
-        voting: false
+        vars:
+          tox_install_bindep: false
 
 
 #

--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -241,14 +241,14 @@ override:
         vars:
           extra_commands:
             - 'dnf install -y python3-stestr python3-oslotest python3-testscenarios'
-            - 'pip install os-win>=3.0.0 requests-aws>=0.1.4 confluent-kafka kazoo'
+            - 'pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt os-win>=3.0.0 requests-aws>=0.1.4 confluent-kafka kazoo'
     'osp-17.1':
       'osp-rpm-py39':
         voting: false
         vars:
           extra_commands:
             - 'dnf install -y python3-stestr python3-oslotest python3-testscenarios'
-            - 'pip install os-win>=3.0.0 requests-aws>=0.1.4 confluent-kafka kazoo'
+            - 'pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt os-win>=3.0.0 requests-aws>=0.1.4 confluent-kafka kazoo'
 
   'cinder':
     'osp-17.0':
@@ -480,9 +480,8 @@ override:
         vars:
           extra_commands:
             - dnf install -y python3-kazoo python3-oslotest python3-requests-mock python3-stestr python3-testscenarios
-            - pip install monasca-statsd
             - sudo dnf remove -y python3-dns --noautoremove
-            - pip install 'dnspython===1.16.0'
+            - pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt dnspython monasca-statsd
       'osp-tox-pep8':  # rhbz-2132082
         voting: false
     'osp-17.1':
@@ -490,9 +489,8 @@ override:
         vars:
           extra_commands:
             - dnf install -y python3-kazoo python3-oslotest python3-requests-mock python3-stestr python3-testscenarios
-            - pip install monasca-statsd
             - sudo dnf remove -y python3-dns --noautoremove
-            - pip install 'dnspython===1.16.0'
+            - pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt dnspython monasca-statsd
       'osp-tox-pep8':  # rhbz-2132082
         voting: false
 
@@ -960,13 +958,13 @@ override:
         vars:
           extra_commands:
             - 'dnf install -y python3-stestr python3-oslotest python3-requests-mock'
-            - 'pip install osprofiler>=1.4.0'
+            - 'pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt osprofiler>=1.4.0'
     'osp-17.1':
       'osp-rpm-py39':
         vars:
           extra_commands:
             - 'dnf install -y python3-stestr python3-oslotest python3-requests-mock'
-            - 'pip install osprofiler>=1.4.0'
+            - 'pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt osprofiler>=1.4.0'
 
   'python-networking-baremetal':
     'osp-17.0':
@@ -988,8 +986,7 @@ override:
           extra_commands:
             - dnf remove -y python3-neutron
             - dnf remove -y python3-neutronclient
-            - pip install neutron
-            - pip install python-neutronclient
+            - pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt neutron python-neutronclient
     'osp-17.1':
       'osp-rpm-py39':
         vars:
@@ -997,8 +994,7 @@ override:
           extra_commands:
             - dnf remove -y python3-neutron
             - dnf remove -y python3-neutronclient
-            - pip install neutron
-            - pip install python-neutronclient
+            - pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt neutron python-neutronclient
 
   'python-neutron-lib':
     'osp-17.0':
@@ -1015,7 +1011,7 @@ override:
       'osp-rpm-py39':
         vars:
           extra_commands:
-            - 'pip install osprofiler>=1.4.0'
+            - 'pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt osprofiler>=1.4.0'
       'osp-tox-pep8':
         vars:
           extra_commands:
@@ -1024,7 +1020,7 @@ override:
       'osp-rpm-py39':
         vars:
           extra_commands:
-            - 'pip install osprofiler>=1.4.0'
+            - 'pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt osprofiler>=1.4.0'
       'osp-tox-pep8':
         vars:
           extra_commands:
@@ -1055,14 +1051,14 @@ override:
           allow_test_requirements_txt: true
           extra_commands:
             - 'dnf remove -y python3-pbr'
-            - 'pip install oslo.serialization'
+            - 'pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt oslo.serialization'
     'osp-17.1':
       'osp-rpm-py39':
         vars:
           allow_test_requirements_txt: true
           extra_commands:
             - 'dnf remove -y python3-pbr'
-            - 'pip install oslo.serialization'
+            - 'pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt oslo.serialization'
 
   'python-octaviaclient':
     'osp-17.0':
@@ -1263,20 +1259,14 @@ override:
           allow_test_requirements_txt: true
           extra_commands:
             - dnf remove -y python3-pbr
-            - pip install oslo.serialization
-            - pip install keystoneauth1
-            - pip install osc-lib
-            - pip install oslo.log
+            - pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt keystoneauth1 osc-lib oslo.log oslo.serialization
     'osp-17.1':
       'osp-rpm-py39':
         vars:
           allow_test_requirements_txt: true
           extra_commands:
             - dnf remove -y python3-pbr
-            - pip install oslo.serialization
-            - pip install keystoneauth1
-            - pip install osc-lib
-            - pip install oslo.log
+            - pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt keystoneauth1 osc-lib oslo.log oslo.serialization
 
   'python-scciclient':
     'osp-17.0':
@@ -1285,14 +1275,14 @@ override:
           allow_test_requirements_txt: true
           extra_commands:
             - 'dnf remove -y python3-pbr'
-            - 'pip install oslo.serialization'
+            - 'pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt oslo.serialization'
     'osp-17.1':
       'osp-rpm-py39':
         vars:
           allow_test_requirements_txt: true
           extra_commands:
             - 'dnf remove -y python3-pbr'
-            - 'pip install oslo.serialization'
+            - 'pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt oslo.serialization'
 
   'python-stevedore':
     'osp-17.0':


### PR DESCRIPTION
> Include constraints in Znoyder config

Whenever there is pip install, we should pin the version
of packages to the versions specified for stable/wallaby.

> Update Znoyder config

This will make jobs for heat, nova, swift, tripleo-ansible,
keystoneclient and keystonemiddleware run the tests correctly.
Also the non-voting label for project that was fixed in source
code is removed. Some minor syntax changes to the mapping added.