### PR TITLE
Fix for nova

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -445,12 +445,14 @@ override:
           extra_commands:
             - dnf install -y python3-pycodestyle python3-ddt python3-hacking python3-ironicclient python3-mock python3-oslotest python3-osprofiler python3-requests-mock python3-stestr python3-testresources python3-testscenarios python3-wsgi_intercept
             - pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt pypowervm zVMCloudConnector
+            - dnf remove -y libguestfs libvirt-client
     'osp-17.1':
       'osp-rpm-py39':
         vars:
           extra_commands:
             - dnf install -y python3-pycodestyle python3-ddt python3-hacking python3-ironicclient python3-mock python3-oslotest python3-osprofiler python3-requests-mock python3-stestr python3-testresources python3-testscenarios python3-wsgi_intercept
             - pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt pypowervm zVMCloudConnector
+            - dnf remove -y libguestfs libvirt-client
 
   'openstack-barbican':
     'osp-17.0':


### PR DESCRIPTION
There is a unit test that does not mock libvirt/libguestfs properly and when those are installed in system, there goes a real call which results with timeout due to no expected response. The test will be fixed in upstream, but for now we just remove the problematic packages that come from spec file.