### PR TITLE
Fix for aodh

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -222,15 +222,21 @@ override:
     'osp-17.0':
       'osp-rpm-py39':
         vars:
+          extra_commands:
+            - setcap -r /usr/libexec/mysqld
           tox_envlist: 'py39-mysql'
           tox_environment:
             AODH_TEST_DRIVERS: 'mysql'
+          tox_install_bindep: true
     'osp-17.1':
       'osp-rpm-py39':
         vars:
+          extra_commands:
+            - setcap -r /usr/libexec/mysqld
           tox_envlist: 'py39-mysql'
           tox_environment:
             AODH_TEST_DRIVERS: 'mysql'
+          tox_install_bindep: true
 
   'ceilometer':
     'osp-17.0':


### PR DESCRIPTION
Finally, we found a way to make aodh jobs green.
There are two main problems:
1) the tests for postresql are running no matter
   we specify backed to MySQL, hence we pass bindep.txt
   to install the dependencies,
2) the mysqld file in RHEL containers contains some
   extra capabilities requirements in order to run,
   which requires container to be deployed with
   --privileged or --cap-add SYS_NICE options [1][2].

[1] https://bugs.mysql.com/bug.php?id=91395
[2] https://unix.stackexchange.com/a/303424