### PR TITLE
Enable additional jobs + minor improvements

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -38,11 +38,11 @@ branches:
 include:
   'osp-17.0':
     'openstack-tox-pep8': 'osp-tox-pep8'
-    'openstack-tox-py39': 'osp-rpm-py39'
+    'openstack-tox-py38': 'osp-rpm-py39'
     'swift-tox-py39': 'osp-rpm-py39'
   'osp-17.1':
     'openstack-tox-pep8': 'osp-tox-pep8'
-    'openstack-tox-py39': 'osp-rpm-py39'
+    'openstack-tox-py38': 'osp-rpm-py39'
     'swift-tox-py39': 'osp-rpm-py39'
     # 'openstack-tox-functional-py39': 'osp-tox-functional-py39'
     # 'cinder-tox-functional-py39': 'cinder-tox-functional-py39'
@@ -109,7 +109,7 @@ add:
           extra_commands:
             - dnf install -y python3-hacking
 
-  'python-openstacksdk':
+  'python-scciclient':
     'osp-17.0':
       'osp-rpm-py39':
         pipeline:
@@ -118,22 +118,6 @@ add:
       'osp-rpm-py39':
         pipeline:
           - 'check'
-
-  'python-zaqarclient':
-    'osp-17.0':
-      'osp-rpm-py39':
-        pipeline:
-          - 'check'
-        vars:
-          extra_commands:
-            - dnf install -y python3-ddt python3-hacking python3-osc-lib-tests python3-oslotest python3-pbr python3-pycodestyle python3-requests-mock python3-stestr python3-testresources
-    'osp-17.1':
-      'osp-rpm-py39':
-        pipeline:
-          - 'check'
-        vars:
-          extra_commands:
-            - dnf install -y python3-ddt python3-hacking python3-osc-lib-tests python3-oslotest python3-pbr python3-pycodestyle python3-requests-mock python3-stestr python3-testresources
 
 
 #
@@ -1303,6 +1287,18 @@ override:
         vars:
           extra_commands:
             - sed -i -r 's/PrettyTable<0.8,>=0.7.2/PrettyTable>=3.3.0/' {{ zuul.project.src_dir }}/requirements.txt
+
+  'python-zaqarclient':
+    'osp-17.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-ddt python3-hacking python3-osc-lib-tests python3-oslotest python3-pbr python3-pycodestyle python3-requests-mock python3-stestr python3-testresources
+    'osp-17.1':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-ddt python3-hacking python3-osc-lib-tests python3-oslotest python3-pbr python3-pycodestyle python3-requests-mock python3-stestr python3-testresources
 
   'swift':
     'osp-17.0':

--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -39,9 +39,11 @@ include:
   'osp-17.0':
     'openstack-tox-pep8': 'osp-tox-pep8'
     'openstack-tox-py39': 'osp-rpm-py39'
+    'swift-tox-py39': 'osp-rpm-py39'
   'osp-17.1':
     'openstack-tox-pep8': 'osp-tox-pep8'
     'openstack-tox-py39': 'osp-rpm-py39'
+    'swift-tox-py39': 'osp-rpm-py39'
     # 'openstack-tox-functional-py39': 'osp-tox-functional-py39'
     # 'cinder-tox-functional-py39': 'cinder-tox-functional-py39'
     # 'nova-tox-functional-py39': 'nova-tox-functional-py39'
@@ -132,30 +134,6 @@ add:
         vars:
           extra_commands:
             - dnf install -y python3-ddt python3-hacking python3-osc-lib-tests python3-oslotest python3-pbr python3-pycodestyle python3-requests-mock python3-stestr python3-testresources
-
-  'swift':
-    'osp-17.0':
-      'osp-rpm-py39':
-        branches: ^rhos-17.0-trunk-patches$
-        vars:
-          rhos_release_args: '17.0'
-          rhos_release_extra_repos: rhelosp-17.0-trunk-brew
-          extra_commands:
-            - dnf install -y liberasurecode-devel python3-coverage python3-dns python3-mock python3-nose-1.3.7 python3-requests-mock python3-swift-tests
-            - cp /usr/lib/python3.9/site-packages/swift/test/sample.conf /etc/swift/test.conf
-            - sed -i -r 's/swift_hash_path_suffix = %SWIFT_HASH_PATH_SUFFIX%/swift_hash_path_suffix = testing/' /etc/swift/swift.conf
-            - sed -i '/self.assertEqual(expected_args, syslog_handler_args)/d' {{ zuul.project.src_dir }}/test/unit/common/test_utils.py
-    'osp-17.1':
-      'osp-rpm-py39':
-        branches: ^rhos-17.1-trunk-patches$
-        vars:
-          rhos_release_args: '17.1'
-          rhos_release_extra_repos: rhelosp-17.1-trunk-brew
-          extra_commands:
-            - dnf install -y liberasurecode-devel python3-coverage python3-dns python3-mock python3-nose-1.3.7 python3-requests-mock python3-swift-tests
-            - cp /usr/lib/python3.9/site-packages/swift/test/sample.conf /etc/swift/test.conf
-            - sed -i -r 's/swift_hash_path_suffix = %SWIFT_HASH_PATH_SUFFIX%/swift_hash_path_suffix = testing/' /etc/swift/swift.conf
-            - sed -i '/self.assertEqual(expected_args, syslog_handler_args)/d' {{ zuul.project.src_dir }}/test/unit/common/test_utils.py
 
 
 #
@@ -1328,20 +1306,28 @@ override:
 
   'swift':
     'osp-17.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y liberasurecode-devel python3-coverage python3-dns python3-mock python3-nose-1.3.7 python3-requests-mock python3-swift-tests
+            - cp /usr/lib/python3.9/site-packages/swift/test/sample.conf /etc/swift/test.conf
+            - sed -i -r 's/swift_hash_path_suffix = %SWIFT_HASH_PATH_SUFFIX%/swift_hash_path_suffix = testing/' /etc/swift/swift.conf
+            - sed -i '/self.assertEqual(expected_args, syslog_handler_args)/d' {{ zuul.project.src_dir }}/test/unit/common/test_utils.py
       'osp-tox-pep8':
-        irrelevant-files:
-          - ^(api-ref|etc|examples|releasenotes)/.*$
-          - ^doc/(requirements.txt|(saio|s3api|source)/.*)$
         vars:
           rhos_release_args: '17.0'
           rhos_release_extra_repos: rhelosp-17.0-trunk-brew
           extra_commands:
             - dnf install -y liberasurecode-devel python3-mock python3-nose python3-swift
     'osp-17.1':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y liberasurecode-devel python3-coverage python3-dns python3-mock python3-nose-1.3.7 python3-requests-mock python3-swift-tests
+            - cp /usr/lib/python3.9/site-packages/swift/test/sample.conf /etc/swift/test.conf
+            - sed -i -r 's/swift_hash_path_suffix = %SWIFT_HASH_PATH_SUFFIX%/swift_hash_path_suffix = testing/' /etc/swift/swift.conf
+            - sed -i '/self.assertEqual(expected_args, syslog_handler_args)/d' {{ zuul.project.src_dir }}/test/unit/common/test_utils.py
       'osp-tox-pep8':
-        irrelevant-files:
-          - ^(api-ref|etc|examples|releasenotes)/.*$
-          - ^doc/(requirements.txt|(saio|s3api|source)/.*)$
         vars:
           rhos_release_args: '17.1'
           rhos_release_extra_repos: rhelosp-17.1-trunk-brew

--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -107,16 +107,6 @@ add:
           extra_commands:
             - dnf install -y python3-hacking
 
-  'python-keystonemiddleware':
-    'osp-17.0':
-      'osp-rpm-py39':
-        pipeline:
-          - 'check'
-    'osp-17.1':
-      'osp-rpm-py39':
-        pipeline:
-          - 'check'
-
   'python-openstacksdk':
     'osp-17.0':
       'osp-rpm-py39':

--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -140,6 +140,7 @@ override:
     'osp-17.0':
       'osp-rpm-py39':
         voting: true
+        branches: ~
         required-projects: ~
         vars:
           rhos_release_args: '17.0'
@@ -150,6 +151,7 @@ override:
     'osp-17.1':
       'osp-rpm-py39':
         voting: true
+        branches: ~
         required-projects: ~
         vars:
           rhos_release_args: '17.1'


### PR DESCRIPTION
Drop branches parameter from inherited jobs

    Some of the inherited jobs for some reason contained
    the specification of trigger branch to master, which
    caused issues with our templater engine during jobs
    definition generation (we inject our branch pattern
    anyway), hence the propsal is to remove such projects.

Inherit py38 as py39 jobs instead of py39 only

    I noticed that there are few projects in upstream that
    contain definitions for py38, but not for py39 (which is
    expected, as py38 was official for stable/wallaby).
    Hence the proposal is to take py38 jobs and rename to py39,
    which extends the downstream coverage to following projects:
    - networking-l2gw
    - python-designateclient
    - python-keystoneauth1
    - python-magnumclient
    - python-osc-placement
    - python-proliantutils
    - python-tooz
    The only drawback is that scciclient has no jobs for py38,
    so we replace openstacksdk with scciclient in add map
    to still contain jobs for this project.

Mapping update for swift

    This moves the definition of unit tests job from add map
    to the override map with inheritance of upstream definition.

Remove add for keystonemiddleware

    The upstream job tox-py39 appears now to be defined,
    so we no longer need to add the jobs, because in current
    case it results in duplicated definition.