### PR TITLE
Remove workarounds for glanceclient pep8 jobs

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -800,19 +800,11 @@ override:
         vars:
           extra_commands:
             - dnf install -y python3-ddt python3-requests-mock python3-stestr python3-testscenarios
-      'osp-tox-pep8':
-        vars:
-          extra_commands:
-            - sed -i -r 's!constraints/upper/master!constraints/upper/wallaby!' {{ zuul.project.src_dir }}/tox.ini
     'osp-17.1':
       'osp-rpm-py39':
         vars:
           extra_commands:
             - dnf install -y python3-ddt python3-requests-mock python3-stestr python3-testscenarios
-      'osp-tox-pep8':
-        vars:
-          extra_commands:
-            - sed -i -r 's!constraints/upper/master!constraints/upper/wallaby!' {{ zuul.project.src_dir }}/tox.ini
 
   'python-heatclient':
     'osp-17.0':


### PR DESCRIPTION
The repositories were synced, the sed is no longer necessary.