### PR TITLE
Road to OSP 16 support

### DIFF
--- a/znoyder/config.py
+++ b/znoyder/config.py
@@ -28,6 +28,7 @@ with pkg_resources.open_text(__package__, 'config.yml') as file:
     CONFIG = yaml.load(file, Loader=yaml.FullLoader)
 
 branches_map = CONFIG.get('branches', {})
+extra_projects = CONFIG.get('extra_projects', {})
 include_map = CONFIG.get('include', {})
 exclude_map = CONFIG.get('exclude', {})
 add_map = CONFIG.get('add', {})

--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -20,6 +20,12 @@
 # Branches config
 #
 branches:
+  'osp-16.1':
+    downstream: '^rhos-16.1-trunk-patches$'
+    upstream: 'stable/train'
+  'osp-16.2':
+    downstream: '^rhos-16.2-trunk-patches$'
+    upstream: 'stable/train'
   'osp-17.0':
     downstream: '^rhos-17.0-trunk-patches$'
     upstream: 'stable/wallaby'
@@ -43,6 +49,8 @@ extra_projects:
 #     '<upstream-job-name>': '<downstream-job-name>'
 #
 include:
+  # 'osp-16.1': ~  # we intentionally do not include anything for OSP 16 here
+  # 'osp-16.2': ~  # we intentionally do not include anything for OSP 16 here
   'osp-17.0':
     'nova-tox-functional-py38': 'osp-rpm-functional-py39'
     'openstack-tox-functional': 'osp-rpm-functional-py39'
@@ -145,6 +153,30 @@ add:
 #
 override:
   /.*/:  # every project
+    'osp-16.1':
+      'osp-rpm-py36':
+        voting: true
+        branches: ~
+        required-projects: ~
+        vars:
+          rhos_release_args: '16.1-cdn'
+          rhos_release_extra_repos: 'rhelosp-16.1-unittest'
+      'osp-tox-pep8':
+        voting: true
+        branches: ~
+        required-projects: ~
+    'osp-16.2':
+      'osp-rpm-py36':
+        voting: true
+        branches: ~
+        required-projects: ~
+        vars:
+          rhos_release_args: '16.2-cdn'
+          rhos_release_extra_repos: 'rhelosp-16.2-unittest'
+      'osp-tox-pep8':
+        voting: true
+        branches: ~
+        required-projects: ~
     'osp-17.0':
       'osp-rpm-py39':
         voting: true
@@ -1558,6 +1590,12 @@ copy:
           from: 'check'
           to: 'gate'
       - 'osp-rpm-functional-py39':
+          from: 'check'
+          to: 'weekly'
+      - 'osp-rpm-py36':
+          from: 'check'
+          to: 'gate'
+      - 'osp-rpm-py36':
           from: 'check'
           to: 'weekly'
       - 'osp-rpm-py39':

--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -29,6 +29,13 @@ branches:
 
 
 #
+# Additional projects to be covered
+#
+extra_projects:
+  python-neutron-tests-tempest: https://opendev.org/openstack/neutron-tempest-plugin.git
+
+
+#
 # Include map: specify which upstream jobs to collect
 #
 # Format:

--- a/znoyder/generator.py
+++ b/znoyder/generator.py
@@ -170,7 +170,7 @@ def generate_projects_pipelines_dict(args):
             jobs = discover_jobs(project_name, osp_tag, directory,
                                  templates, pipelines)
 
-            if not jobs:
+            if not jobs and project_name not in projects_pipelines_dict:
                 projects_pipelines_dict[project_name] = defaultdict(list)
 
             for job in jobs:

--- a/znoyder/generator.py
+++ b/znoyder/generator.py
@@ -25,6 +25,7 @@ from yaml.parser import ParserError
 
 from znoyder import browser
 from znoyder.config import branches_map
+from znoyder.config import extra_projects
 from znoyder.config import GENERATED_CONFIGS_DIR
 from znoyder.config import GENERATED_CONFIG_PREFIX
 from znoyder.config import GENERATED_CONFIG_EXTENSION
@@ -78,6 +79,10 @@ def fetch_osp_projects(branch: str, filters: dict) -> list:
     projects = {package.get('osp-project'): package.get('upstream')
                 for package in browser.get_packages(**filters)
                 if package.get('osp-project')}
+
+    for project in extra_projects:
+        if project not in projects:
+            projects[project] = extra_projects[project]
 
     for osp_name, repository in projects.items():
         project_urls = downloader.download_zuul_config(

--- a/znoyder/tests/test_generator.py
+++ b/znoyder/tests/test_generator.py
@@ -23,6 +23,7 @@ from unittest.mock import patch
 
 from yaml.parser import ParserError
 
+from znoyder.config import extra_projects
 from znoyder.config import UPSTREAM_CONFIGS_DIR
 from znoyder.generator import cleanup_generated_jobs_dir
 from znoyder.generator import fetch_templates_directory
@@ -133,6 +134,9 @@ class TestGenerator(TestCase):
     @patch('znoyder.downloader.download_zuul_config')
     @patch('znoyder.browser.get_packages')
     def test_fetch_osp_projects(self, mock_browser, mock_downloader):
+        extra_projects.clear()
+        extra_projects.update({'additional-project': 'url-to-additional-repo'})
+
         mock_browser.return_value = [
             {
                 'osp-project': 'project1',
@@ -154,13 +158,15 @@ class TestGenerator(TestCase):
             {'organization/repository1': ['url-to-yaml-file1']},
             {'organization/repository2': ['url-to-yaml-file2']},
             {'organization/repository3': ['url-to-yaml-file3']},
+            {'additional/project1': ['url-to-yaml-file4']},
         ]
 
         projects = fetch_osp_projects('any-tag', {})
 
         self.assertEqual({'project1': 'any-tag/organization/repository1',
                           'project2': 'any-tag/organization/repository2',
-                          'project3': 'any-tag/organization/repository3'},
+                          'project3': 'any-tag/organization/repository3',
+                          'additional-project': 'any-tag/additional/project1'},
                          projects)
 
     @patch('znoyder.mapper.copy_jobs')


### PR DESCRIPTION
1. Support additional projects

> We need to support some downstream projects that are not directly
> a part of product release, e.g. repositories containing tests
> for specific components and scenarios.

2. Fix for projects with no jobs

> In the current code, if project had jobs for release A,
> but no jobs for release B, then it would result in empty
> list of jobs. This change fixes it.

3. Prepare for OSP 16 support