### PR TITLE
Add py36 jobs where py39 are

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -1604,6 +1604,9 @@ copy:
       - 'osp-rpm-py39':
           from: 'check'
           to: 'weekly'
+      - 'osp-rpm-py39':
+          as: 'osp-rpm-py36'
+          from: 'weekly'
       - 'osp-tox-pep8':
           from: 'check'
           to: 'gate'


### PR DESCRIPTION
This commit enables additionaly py36 for OSP 17 where the py39 jobs are currently. This is becasue we noticed there are some RHEL8-based puddles still.

For now only periodic jobs to track statuses.