### PR TITLE
Add support for GitHub API token

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps = -r requirements.txt
 
 [testenv:run]
 commands = {posargs}
+passenv = GITHUB_USERNAME GITHUB_TOKEN
 
 [testenv:coverage]
 commands =

--- a/znoyder/tests/test_downloader.py
+++ b/znoyder/tests/test_downloader.py
@@ -104,7 +104,7 @@ class TestDownloader(TestCase):
 
         data = get_raw_url_files_in_repository(repo, {}, errors_fatal=False)
         self.assertEqual(data, {repo: []})
-        patched_get.assert_called_with(url=url)
+        patched_get.assert_called_with(url=url, auth=None)
 
     @patch("requests.get")
     def test_get_raw_url_get_files(self, patched_get):


### PR DESCRIPTION
The rate limit for unauthenticated GitHub requests is really small (60 per hour from a given IP address). Therefore using a personal access token may be necessary in some cases.