### PR TITLE
Mapping for OSP 16 jobs

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -38,6 +38,7 @@ branches:
 # Additional projects to be covered
 #
 extra_projects:
+  networking-ovn: https://opendev.org/openstack/networking-ovn
   python-neutron-tests-tempest: https://opendev.org/openstack/neutron-tempest-plugin.git
 
 
@@ -99,12 +100,204 @@ exclude: {}
 #         'type': ['check']
 #
 add:
+  'cinder':
+    'osp-16.1':
+      'osp-rpm-functional-py36':
+        vars:
+          tox_envlist: functional
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          allow_test_requirements_txt: true
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - ln -s /usr/bin/python3 /usr/bin/python
+          tox_install_bindep: false
+    'osp-16.2':
+      'osp-rpm-functional-py36':
+        vars:
+          tox_envlist: functional
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          allow_test_requirements_txt: true
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - ln -s /usr/bin/python3 /usr/bin/python
+          tox_install_bindep: false
+
+  'glance':
+    'osp-16.1':
+      'osp-rpm-functional-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-mock python3-oslotest python3-stestr python3-testresources python3-testscenarios
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          allow_test_requirements_txt: true
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+    'osp-16.2':
+      'osp-rpm-functional-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-mock python3-oslotest python3-stestr python3-testresources python3-testscenarios
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          allow_test_requirements_txt: true
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+
+  'glance_store':
+    'osp-16.1':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-boto3 python3-oslotest python3-oslo-vmware python3-requests-mock python3-retrying python3-stestr python3-swiftclient
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - sed -i -r '/minversion/a requires = virtualenv<20.8' {{ zuul.project.src_dir }}/tox.ini
+    'osp-16.2':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-boto3 python3-oslotest python3-oslo-vmware python3-requests-mock python3-retrying python3-stestr python3-swiftclient
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - sed -i -r '/minversion/a requires = virtualenv<20.8' {{ zuul.project.src_dir }}/tox.ini
+
   'gnocchi':
     'osp-17.0':
       'osp-tox-pep8':
         pipeline:
           - 'check'
     'osp-17.1':
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+
+  'manila':
+    'osp-16.1':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-mock python3-oslotest python3-requests-mock python3-stestr python3-testresources
+            - pip3 install pep8
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - ln -s /usr/bin/python3 /usr/bin/python
+    'osp-16.2':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-mock python3-oslotest python3-requests-mock python3-stestr python3-testresources
+            - pip3 install pep8
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - ln -s /usr/bin/python3 /usr/bin/python
+
+  'neutron':
+    'osp-16.1':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-neutron-lib-tests
+            - dnf remove -y python3-flake8
+            - pip3 install 'flake8<3.0' 'hacking'
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          tox_install_bindep: false
+    'osp-16.2':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-neutron-lib-tests
+            - dnf remove -y python3-flake8
+            - pip3 install 'flake8<3.0' 'hacking'
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          tox_install_bindep: false
+
+  'networking-ovn':
+    'osp-16.1':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-mock python3-neutron-lib-tests python3-neutron-tests python3-os-testr
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+    'osp-16.2':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-mock python3-neutron-lib-tests python3-neutron-tests python3-os-testr
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+
+  'octavia':
+    'osp-16.1':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+    'osp-16.2':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
       'osp-tox-pep8':
         pipeline:
           - 'check'
@@ -125,6 +318,184 @@ add:
           extra_commands:
             - dnf install -y python3-hacking
 
+  'python-cinderclient':
+    'osp-16.1':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          allow_test_requirements_txt: true
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          tox_install_bindep: false
+    'osp-16.2':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          allow_test_requirements_txt: true
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          tox_install_bindep: false
+
+  'python-cinderlib':
+    'osp-16.1':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - sed -i -r '/minversion/a requires = virtualenv<20.8' {{ zuul.project.src_dir }}/tox.ini
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - sed -i -r '/minversion/a requires = virtualenv<20.8' {{ zuul.project.src_dir }}/tox.ini
+    'osp-16.2':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - sed -i -r '/minversion/a requires = virtualenv<20.8' {{ zuul.project.src_dir }}/tox.ini
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - sed -i -r '/minversion/a requires = virtualenv<20.8' {{ zuul.project.src_dir }}/tox.ini
+
+  'python-glanceclient':
+    'osp-16.1':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-mock python3-requests-mock python3-stestr python3-testscenarios
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+    'osp-16.2':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-mock python3-requests-mock python3-stestr python3-testscenarios
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+
+  'python-manilaclient':
+    'osp-16.1':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-ddt python3-mock python3-stestr pythone3-tempest
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          tox_install_bindep: false
+    'osp-16.2':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-ddt python3-mock python3-stestr python3-tempest
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          tox_install_bindep: false
+
+  'python-neutron-lib':
+    'osp-16.1':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-mock python3-oslotest python3-stestr python3-testresources python3-testscenarios
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - sed -i -r 's#https://opendev.org/openstack/requirements/raw/branch/master/upper-constraints.txt#https://opendev.org/openstack/requirements/raw/branch/stable/train/upper-constraints.txt#g' {{ zuul.project.src_dir }}/tox.ini
+    'osp-16.2':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-mock python3-oslotest python3-stestr python3-testresources python3-testscenarios
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - sed -i -r 's#https://opendev.org/openstack/requirements/raw/branch/master/upper-constraints.txt#https://opendev.org/openstack/requirements/raw/branch/stable/train/upper-constraints.txt#g' {{ zuul.project.src_dir }}/tox.ini
+
+  'python-neutron-tests-tempest':
+    'osp-16.1':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - sed -i -r 's#tempest>=17.1.0#tempest>=17.1.0,<=22.1.0#g' {{ zuul.project.src_dir }}/requirements.txt
+            - sed -i -r 's#hacking<0.13,>=0.12.0#hacking#g' {{ zuul.project.src_dir }}/test-requirements.txt
+    'osp-16.2':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - sed -i -r 's#tempest>=17.1.0#tempest>=17.1.0,<=22.1.0#g' {{ zuul.project.src_dir }}/requirements.txt
+            - sed -i -r 's#hacking<0.13,>=0.12.0#hacking#g' {{ zuul.project.src_dir }}/test-requirements.txt
+
+  'python-os-brick':
+    'osp-16.1':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-castellan python3-ddt python3-mock python3-oslo-vmware python3-stestr
+      'osp-tox-pep8':
+        vars:
+          extra_commands:
+            - sed -i -r '/minversion/a requires = virtualenv<20.8' {{ zuul.project.src_dir }}/tox.ini
+    'osp-16.2':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-castellan python3-ddt python3-mock python3-oslo-vmware python3-stestr
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - sed -i -r '/minversion/a requires = virtualenv<20.8' {{ zuul.project.src_dir }}/tox.ini
+
   'python-scciclient':
     'osp-17.0':
       'osp-rpm-py39':
@@ -134,6 +505,32 @@ add:
       'osp-rpm-py39':
         pipeline:
           - 'check'
+
+  'python-swiftclient':
+    'osp-16.1':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-mock python3-stestr
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          tox_install_bindep: false
+    'osp-16.2':
+      'osp-rpm-py36':
+        pipeline:
+          - 'check'
+        vars:
+          extra_commands:
+            - dnf install -y python3-mock python3-stestr
+      'osp-tox-pep8':
+        pipeline:
+          - 'check'
+        vars:
+          tox_install_bindep: false
 
 
 #
@@ -154,6 +551,14 @@ add:
 override:
   /.*/:  # every project
     'osp-16.1':
+      'osp-rpm-functional-py36':
+        voting: true
+        branches: ~
+        nodeset: 'pod-rhel-8.2'
+        required-projects: ~
+        vars:
+          rhos_release_args: '16.1-cdn'
+          rhos_release_extra_repos: 'rhelosp-16.1-unittest'
       'osp-rpm-py36':
         voting: true
         branches: ~
@@ -170,6 +575,14 @@ override:
         vars:
           rhos_release_extra_repos: 'rhosp-rhel-8.2-crb'
     'osp-16.2':
+      'osp-rpm-functional-py36':
+        voting: true
+        branches: ~
+        nodeset: 'pod-rhel-8.4'
+        required-projects: ~
+        vars:
+          rhos_release_args: '16.2-cdn'
+          rhos_release_extra_repos: 'rhelosp-16.2-unittest'
       'osp-rpm-py36':
         voting: true
         branches: ~
@@ -328,8 +741,6 @@ override:
     'osp-17.0':
       'osp-rpm-py39':
         vars:
-          rhos_release_args: '17.0'
-          rhos_release_extra_repos: rhelosp-17.0-trunk-brew
           extra_commands:
             - dnf install -y python3-boto3 python3-oslotest python3-oslo-vmware python3-requests-mock python3-retrying python3-stestr python3-swiftclient
       'osp-tox-pep8':
@@ -339,8 +750,6 @@ override:
     'osp-17.1':
       'osp-rpm-py39':
         vars:
-          rhos_release_args: '17.1'
-          rhos_release_extra_repos: rhelosp-17.1-trunk-brew
           extra_commands:
             - dnf install -y python3-boto3 python3-oslotest python3-oslo-vmware python3-requests-mock python3-retrying python3-stestr python3-swiftclient
       'osp-tox-pep8':


### PR DESCRIPTION
Covers the following projects:
– cinder
– glance_store
– python-cinderclient
– python-glanceclient
– python-os-brick
– python-swiftclient
– glance
– manila
– python-cinderlib
– python-manilaclient
– neutron
– neutron-lib
– networking-ovn
– python-neutron-tests-tempest
– octavia

The following will be covered in a further patch:
– nova
– swift