### PR TITLE
Don't install pypowervm and zVMCloudConnector on 16.1

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -300,7 +300,6 @@ add:
         vars:
           extra_commands:
             - dnf install -y python3-pycodestyle python3-ddt python3-hacking python3-ironicclient python3-mock python3-oslotest python3-osprofiler python3-requests-mock python3-stestr python3-testresources python3-testscenarios python3-wsgi_intercept python3-os-xenapi
-            - pip3 install -c https://opendev.org/openstack/requirements/raw/branch/stable/train/upper-constraints.txt pypowervm zVMCloudConnector
             - dnf remove -y libguestfs libvirt-client
       'osp-tox-pep8':
         pipeline:


### PR DESCRIPTION
These are upstream requirements, but downstream OSP only supports the
libvirt and ironic virt drivers. By not unit testing virt drivers that
we don't support, we can simplify our CI.
