### PR TITLE
Replace RHEL 9.2 CRB repo with 9.2 beta version

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -772,7 +772,7 @@ override:
         required-projects: ~
         vars:
           rhos_release_args: '17.1'
-          rhos_release_extra_repos: 'rhelosp-17.1-trunk-brew rhosp-rhel-9.2-crb'
+          rhos_release_extra_repos: 'rhelosp-17.1-trunk-brew rhosp-rhel-9.2-beta-crb'
 
   'ansible-tripleo-ipa':
     'osp-17.0':


### PR DESCRIPTION
The original repo is no longer available -- we can use RHEL 9.2 beta [1] content while waiting for its GA to arrive.

[1] https://access.redhat.com/announcements/7003578