### PR TITLE
Revert "Replace RHEL 9.2 CRB repo with 9.2 beta version"

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -772,7 +772,7 @@ override:
         required-projects: ~
         vars:
           rhos_release_args: '17.1'
-          rhos_release_extra_repos: 'rhelosp-17.1-trunk-brew rhosp-rhel-9.2-beta-crb'
+          rhos_release_extra_repos: 'rhelosp-17.1-trunk-brew rhosp-rhel-9.2-crb'
 
   'ansible-tripleo-ipa':
     'osp-17.0':


### PR DESCRIPTION
9.2 is now GA and repo is available.
This reverts commit 7b9187c9be18e09a4828e5debcef319deb416575.