### PR TITLE
Add OSP 18 jobs for Nova

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -32,6 +32,9 @@ branches:
   'osp-17.1':
     downstream: '^rhos-17.1-trunk-patches$'
     upstream: 'stable/wallaby'
+  'osp-18.0':
+    downstream: '^rhos-18.0-trunk-patches$'
+    upstream: 'stable/2023.1'
 
 
 #
@@ -1217,6 +1220,17 @@ override:
             - dnf install -y python3-pycodestyle python3-ddt python3-hacking python3-ironicclient python3-mock python3-oslotest python3-osprofiler python3-requests-mock python3-stestr python3-testresources python3-testscenarios python3-wsgi_intercept
             - pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt pypowervm zVMCloudConnector
             - dnf remove -y libguestfs libvirt-client
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-pycodestyle python3-ddt python3-hacking python3-ironicclient python3-mock python3-oslotest python3-osprofiler python3-requests-mock python3-stestr python3-testresources python3-testscenarios python3-wsgi_intercept
+            - pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/wallaby/upper-constraints.txt pypowervm zVMCloudConnector
+            - dnf remove -y libguestfs libvirt-client
+    'osp-18.0':
+      'osp-rpm-functional-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-ddt python3-ironicclient python3-mock python3-oslotest python3-osprofiler python3-placement-tests python3-stestr python3-testresources python3-testscenarios python3-wsgi_intercept
       'osp-rpm-py39':
         vars:
           extra_commands:
@@ -2867,7 +2881,6 @@ override:
       'osp-tox-pep8':
         vars:
           tox_install_bindep: false
-
 
 #
 # Copy map: duplicate a job entry from one pipeline/project to another

--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -77,6 +77,15 @@ include:
     'swift-tox-func-py37': 'osp-rpm-functional-py39'
     'swift-tox-py36': 'osp-rpm-py36'
     'swift-tox-py39': 'osp-rpm-py39'
+  'osp-18.0':
+    'nova-tox-functional-py39': 'osp-rpm-functional-py39'
+    'openstack-tox-functional': 'osp-rpm-functional-py39'
+    'openstack-tox-functional-py39': 'osp-rpm-functional-py39'
+    'openstack-tox-pep8': 'osp-tox-pep8'
+    'openstack-tox-py39': 'osp-rpm-py39'
+    'placement-nova-tox-functional-py39': 'osp-rpm-functional-py39'
+    'swift-tox-func-py39': 'osp-rpm-functional-py39'
+    'swift-tox-py39': 'osp-rpm-py39'
 
 
 #
@@ -776,6 +785,31 @@ override:
         vars:
           rhos_release_args: '17.1'
           rhos_release_extra_repos: 'rhelosp-17.1-trunk-brew rhosp-rhel-9.2-crb'
+    'osp-18.0':
+      'osp-rpm-py39':
+        voting: true
+        branches: ~
+        nodeset: 'pod-rhel-9.2'
+        required-projects: ~
+        vars:
+          rhos_release_args: '18.0'
+          rhos_release_extra_repos: 'rhelosp-18.0-trunk-brew'
+      'osp-rpm-functional-py39':
+        voting: true
+        branches: ~
+        nodeset: 'pod-rhel-9.2'
+        required-projects: ~
+        vars:
+          rhos_release_args: '18.0'
+          rhos_release_extra_repos: 'rhelosp-18.0-trunk-brew'
+      'osp-tox-pep8':
+        voting: true
+        branches: ~
+        nodeset: 'pod-rhel-9.2'
+        required-projects: ~
+        vars:
+          rhos_release_args: '18.0'
+          rhos_release_extra_repos: 'rhelosp-18.0-trunk-brew rhosp-rhel-9.2-crb'
 
   'ansible-tripleo-ipa':
     'osp-17.0':
@@ -2881,6 +2915,7 @@ override:
       'osp-tox-pep8':
         vars:
           tox_install_bindep: false
+
 
 #
 # Copy map: duplicate a job entry from one pipeline/project to another


### PR DESCRIPTION
We're slowly starting to see OSP 18.0 backport to Nova downstream. Add
basic functional and unit tests jobs as a sanity check for those
backports. These are copied verbatim from the 17.1 versions (minus the
py36 unit tests job), working on the assumption that we can run them
on RHEL 9.2 for now and everything will be fine.
