### PR TITLE
Support splitting config to multiple files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ console_scripts =
 [package_data]
 znoyder =
     znoyder/config.yml
+    znoyder/config.d/*.yml
     znoyder/templates/*
 
 [egg_info]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,9 @@ deps = -r requirements.txt
 
 [testenv:run]
 commands = {posargs}
-passenv = GITHUB_USERNAME GITHUB_TOKEN
+passenv =
+    GITHUB_USERNAME
+    GITHUB_TOKEN
 
 [testenv:coverage]
 commands =

--- a/znoyder/config.py
+++ b/znoyder/config.py
@@ -23,9 +23,17 @@ except ImportError:  # Fallback for Python < 3.7
 
 import yaml
 
+from znoyder.utils import merge_dicts
+
 
 with pkg_resources.open_text(__package__, 'config.yml') as file:
     CONFIG = yaml.load(file, Loader=yaml.FullLoader)
+
+configd_files = sorted(pkg_resources.files(__package__).glob('config.d/*.yml'))
+for configd_file in configd_files:
+    with open(configd_file, 'r') as file:
+        additional_config = yaml.load(file, Loader=yaml.FullLoader)
+        merge_dicts(CONFIG, additional_config, override=True)
 
 branches_map = CONFIG.get('branches', {})
 extra_projects = CONFIG.get('extra_projects', {})


### PR DESCRIPTION
As the config.yml file becomes larger and larger,
it would have more sense to introduce multiple
smaller files, e.g. with per OSP release settings.