### PR TITLE
Copy most OSP 17.1 settings to OSP 18 jobs

### DIFF
--- a/znoyder/config.d/43-override-OSP-18.yml
+++ b/znoyder/config.d/43-override-OSP-18.yml
@@ -27,6 +27,13 @@ override:
           rhos_release_args: '18.0'
           rhos_release_extra_repos: 'rhelosp-18.0-trunk-brew rhosp-rhel-9.2-crb'
 
+  'ansible-tripleo-ipa':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-oslotest python3-stestr
+
   'aodh':
     'osp-18.0':
       'osp-rpm-py39':
@@ -38,12 +45,118 @@ override:
             AODH_TEST_DRIVERS: 'mysql'
           tox_install_bindep: true
 
+  'ceilometer':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-oslotest python3-stestr python3-testscenarios
+
+  'cinder':
+    'osp-18.0':
+      'osp-rpm-functional-py39':
+        vars:
+          tox_envlist: functional
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+      'osp-tox-pep8':
+        vars:
+          tox_install_bindep: false
+
   'glance':
     'osp-18.0':
       'osp-rpm-functional-py39':
         vars:
           extra_commands:
             - dnf install -y python3-ddt python3-oslotest python3-stestr python3-swiftclient python3-testresources python3-testscenarios
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'glance_store':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-boto3 python3-oslotest python3-oslo-vmware python3-requests-mock python3-retrying python3-stestr python3-swiftclient
+
+  'heat':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-ddt python3-hacking python3-monascaclient python3-testscenarios python3-stestr
+
+  'horizon':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'ironic':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'ironic-ui':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+          extra_commands:
+            - dnf install -y openstack-dashboard
+          tox_environment:
+            PYTHONPATH: /usr/share/openstack-dashboard
+            TOX_TESTENV_PASSENV: PYTHONPATH
+
+  'keystone':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-freezegun python3-hacking python3-oslotest python3-pycodestyle python3-stestr python3-testresources python3-testscenarios python3-webtest
+      'osp-tox-pep8':
+        vars:
+          extra_commands:
+            - dnf install -y openldap-devel
+          tox_install_bindep: false
+
+  'manila':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-ddt python3-hacking python3-oslotest python3-pycodestyle python3-requests-mock python3-stestr python3-testresources
+
+  'manila-ui':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+          extra_commands:
+            - dnf install -y openstack-dashboard
+          tox_environment:
+            PYTHONPATH: /usr/share/openstack-dashboard
+            TOX_TESTENV_PASSENV: PYTHONPATH
+
+  'networking-bgpvpn':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y openstack-dashboard python3-networking-bagpipe python3-neutron-tests python3-neutron-lib-tests python3-stestr
+          tox_environment:
+            PYTHONPATH: /usr/share/openstack-dashboard
+            TOX_TESTENV_PASSENV: PYTHONPATH
+
+  'networking-l2gw':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-neutron-tests python3-neutron-lib-tests python3-neutronclient-tests vim
 
   'neutron':
     'osp-18.0':
@@ -62,8 +175,351 @@ override:
         vars:
           extra_commands:
             - dnf install -y python3-pycodestyle python3-ddt python3-hacking python3-ironicclient python3-mock python3-oslotest python3-osprofiler python3-requests-mock python3-stestr python3-testresources python3-testscenarios python3-wsgi_intercept
-            - pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/2023.1/upper-constraints.txt pypowervm zVMCloudConnector
             - dnf remove -y libguestfs libvirt-client
+
+  'openstack-barbican':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'openstack-designate':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-kazoo python3-oslotest python3-requests-mock python3-stestr python3-testscenarios
+
+  'openstack-designate-ui':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+          extra_commands:
+            - dnf install -y openstack-dashboard
+          tox_environment:
+            PYTHONPATH: /usr/share/openstack-dashboard
+            TOX_TESTENV_PASSENV: PYTHONPATH
+
+  'openstack-heat-agents':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y hostname python3-testrepository
+
+  'openstack-heat-ui':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+          extra_commands:
+            - dnf install -y openstack-dashboard
+          tox_environment:
+            PYTHONPATH: /usr/share/openstack-dashboard
+            TOX_TESTENV_PASSENV: PYTHONPATH
+
+  'openstack-ironic-inspector':
+    'osp-18.0':
+      'osp-rpm-functional-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-oslotest python3-stestr python3-testresources python3-testscenarios
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-ddt python3-oslotest python3-requests-mock python3-testresources python3-testscenarios python3-stestr
+
+  'openstack-ironic-python-agent':
+    'osp-18.0':
+      'osp-rpm-functional-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-oslotest python3-stestr
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'openstack-neutron-dynamic-routing':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-neutron-tests python3-neutron-lib-tests
+
+  'openstack-octavia-ui':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+          extra_commands:
+            - dnf install -y openstack-dashboard
+          tox_environment:
+            PYTHONPATH: /usr/share/openstack-dashboard
+            TOX_TESTENV_PASSENV: PYTHONPATH
+
+  'openstack-placement':
+    'osp-18.0':
+      'osp-rpm-functional-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-testresources python3-testscenarios
+
+  'openstack-tripleo-common':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+          extra_commands:
+            - dnf install -y python3-ddt python3-oslotest python3-requests-mock python3-stestr python3-testscenarios
+
+  'openstack-tripleo-heat-templates':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-ddt python3-oslotest python3-requests-mock python3-stestr python3-testscenarios
+      'osp-tox-pep8':
+        vars:
+          tox_install_bindep: false
+
+  'openstack-tripleo-image-elements':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'openstack-tripleo-puppet-elements':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-stestr
+
+  'os-net-config':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'oslo.messaging':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+      'osp-tox-pep8':
+        vars:
+          tox_install_bindep: false
+
+  'oslo.middleware':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'oslo.service':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'oslo.utils':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'oslo.vmware':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'ovn-octavia-provider':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-aodhclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y postgresql-server python3-devel
+
+  'python-automaton':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-barbicanclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y openstack-dashboard python3-coverage python3-requests-mock python3-stestr
+          tox_environment:
+            PYTHONPATH: /usr/share/openstack-dashboard
+            TOX_TESTENV_PASSENV: PYTHONPATH
+
+  'python-castellan':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-ceilometermiddleware':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-betamax python3-oslotest python3-stestr
+
+  'python-cinderclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-cliff':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-docutils python3-pbr python3-stestr
+
+  'python-designateclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-oslotest python3-requests-mock python3-stestr
+
+  'python-dracclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-glanceclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-ddt python3-requests-mock python3-stestr python3-testscenarios
+
+  'python-heatclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-ironic-inspector-client':
+    'osp-18.0':
+      'osp-rpm-functional-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-coverage python3-osc-lib-tests python3-stestr
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-coverage python3-osc-lib-tests python3-stestr
+
+  'python-ironic-lib':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-ironicclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-osc-lib-tests python3-oslotest python3-stestr
+
+  'python-keystoneauth1':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-betamax python3-hacking python3-gssapi python3-kerberos python3-lxml python3-oauthlib python3-oslo-config python3-oslo-utils python3-pycodestyle python3-requests-kerberos python3-requests-mock python3-stestr
+
+  'python-keystoneclient':
+    'osp-18.0':
+      'osp-tox-pep8':
+        vars:
+          tox_install_bindep: false
+
+  'python-keystonemiddleware':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-oslotest python3-oslo-messaging python3-requests-mock python3-stestr python3-testresources python3-webtest
+
+  'python-magnumclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-openstackclient python3-osprofiler
+
+  'python-manilaclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-metalsmith':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-mistralclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-oslotest python3-osprofiler python3-requests-mock python3-stestr
+
+  'python-networking-baremetal':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-neutron-lib-tests
+
+  'python-networking-sfc':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+          extra_commands:
+            - dnf install -y python3-neutron-tests python3-neutron-lib-tests python3-neutronclient-tests
+
+  'python-neutron-lib':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-neutronclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-osprofiler
+
+  'python-novaclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-ddt python3-docutils python3-osprofiler python3-requests-mock python3-stestr python3-testscenarios
 
   'python-octavia-lib':
     'osp-18.0':
@@ -71,3 +527,206 @@ override:
         vars:
           extra_commands:
             - dnf install -y python3-hacking python3-oslotest python3-stestr
+
+  'python-octaviaclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-openstackclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-ddt python3-hacking python3-osc-lib-tests python3-oslotest python3-pycodestyle python3-requests-mock python3-stestr python3-testresources
+
+  'python-openstacksdk':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-ddt python3-hacking python3-jsonschema python3-oslo-config python3-oslotest python3-prometheus_client python3-requests-mock python3-stestr python3-testscenarios
+
+  'python-os-brick':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-castellan python3-ddt python3-oslo-vmware python3-stestr
+
+  'python-os-ken':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-os-win':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-ddt python3-hacking python3-oslotest python3-pycodestyle python3-stestr
+
+  'python-oslo-cache':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-oslo-config':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-oslo-context':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-oslo-db':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-oslo-policy':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-oslo-privsep':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-oslo-upgradecheck':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-oslo-versionedobjects':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-ovsdbapp':
+    'osp-18.0':
+      'osp-rpm-functional-py39':
+        vars:
+          extra_commands:
+            - dnf install -y autoconf automake libtool python3-stestr python3-testscenarios
+          tox_envlist: functional
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-proliantutils':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-ddt python3-mock python3-stestr
+
+  'python-saharaclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-hacking python3-osc-lib-tests python3-requests-mock python3-stestr
+
+  'python-scciclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-requests-mock python3-stestr
+
+  'python-stevedore':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-sushy':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-sushy-oem-idrac':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          allow_test_requirements_txt: true
+
+  'python-swiftclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-mock python3-stestr
+      'osp-tox-pep8':
+        vars:
+          tox_install_bindep: false
+
+  'python-tooz':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-ddt python3-etcd3gw python3-kazoo python3-pymemcache python3-PyMySQL python3-stestr python3-sysv_ipc
+
+  'python-tripleoclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-osc-lib-tests python3-testscenarios python3-stestr
+
+  'python-troveclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-httplib2 python3-requests-mock python3-stestr
+
+  'python-zaqarclient':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-ddt python3-hacking python3-osc-lib-tests python3-oslotest python3-pbr python3-pycodestyle python3-requests-mock python3-stestr python3-testresources
+
+  'swift':
+    'osp-18.0':
+      'osp-rpm-functional-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-boto python3-boto3 python3-mock python3-os-testr python3-swiftclient
+          tox_envlist: func-py3
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y liberasurecode-devel python3-coverage python3-dns python3-mock python3-nose-1.3.7 python3-requests-mock python3-swift-tests
+            - cp /usr/lib/python3.9/site-packages/swift/test/sample.conf /etc/swift/test.conf
+      'osp-tox-pep8':
+        vars:
+          extra_commands:
+            - dnf install -y liberasurecode-devel python3-mock python3-nose python3-swift
+
+  'tripleo-ansible':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - dnf install -y python3-mock python3-oslotest python3-stestr
+      'osp-tox-pep8':
+        vars:
+          tox_install_bindep: false


### PR DESCRIPTION
This includes for now most of extra dnf packages
as well as some environment variables. Very specific settings, such as Python 2to3-related adjustments, were omitted here for the first massive check,
as these are most probably already fixed in projects.