### PR TITLE
Do not install python3-mock and python3-libvirt

### DIFF
--- a/znoyder/config.d/43-override-OSP-18.yml
+++ b/znoyder/config.d/43-override-OSP-18.yml
@@ -170,7 +170,9 @@ override:
       'osp-rpm-functional-py39':
         vars:
           extra_commands:
-            - dnf install -y python3-ddt python3-ironicclient python3-mock python3-oslotest python3-osprofiler python3-placement-tests python3-stestr python3-testresources python3-testscenarios python3-wsgi_intercept
+            - dnf install -y python3-ddt python3-ironicclient python3-oslotest python3-osprofiler python3-placement-tests python3-stestr python3-testresources python3-testscenarios python3-wsgi_intercept
+            - rpm -e --nodeps python3-mock
+            - rpm -e --nodeps python3-libvirt
       'osp-rpm-py39':
         vars:
           extra_commands:


### PR DESCRIPTION
Nova's code mocks out compute manager's with a mock.DEFAULT. However, the python3-placement-tests requires the python3-mock package – we should remove it to use the built-in standard library.

Then there was error regarding python3-libvirt module imported, while it should not be installed. Hence we remove the package. This resolves the issues with osp-rpm-functional-py39 job.