### PR TITLE
Fix for python-os-vif

### DIFF
--- a/znoyder/config.d/42-override-OSP-17.yml
+++ b/znoyder/config.d/42-override-OSP-17.yml
@@ -1057,12 +1057,18 @@ override:
       'osp-rpm-py39':
         vars:
           extra_commands:
+            # This project requires stestr to be within the tox environment,
+            # otherwise the tests ends with os_vif.exception.ExternalImport:
+            # Use of this module outside of os_vif is not allowed. (#bz2109536)
             - echo 'stestr' > {{ zuul.project.src_dir }}/test-requirements.txt
             - sed -i -r 's!constraints/upper/master!constraints/upper/wallaby!' {{ zuul.project.src_dir }}/tox.ini
     'osp-17.1':
       'osp-rpm-py39':
         vars:
           extra_commands:
+            # This project requires stestr to be within the tox environment,
+            # otherwise the tests ends with os_vif.exception.ExternalImport:
+            # Use of this module outside of os_vif is not allowed. (#bz2109536)
             - echo 'stestr' > {{ zuul.project.src_dir }}/test-requirements.txt
             - sed -i -r 's!constraints/upper/master!constraints/upper/wallaby!' {{ zuul.project.src_dir }}/tox.ini
 

--- a/znoyder/config.d/43-override-OSP-18.yml
+++ b/znoyder/config.d/43-override-OSP-18.yml
@@ -582,6 +582,16 @@ override:
         vars:
           allow_test_requirements_txt: true
 
+  'python-os-vif':
+    'osp-18.0':
+      'osp-rpm-py39':
+        vars:
+          extra_commands:
+            # This project requires stestr to be within the tox environment,
+            # otherwise the tests ends with os_vif.exception.ExternalImport:
+            # Use of this module outside of os_vif is not allowed. (#bz2109536)
+            - echo 'stestr' > {{ zuul.project.src_dir }}/test-requirements.txt
+
   'python-os-win':
     'osp-18.0':
       'osp-rpm-py39':


### PR DESCRIPTION
Added fix for OSP 18 and notes for OSP 17 for clearness, as per https://bugzilla.redhat.com/show_bug.cgi?id=2109536