### PR TITLE
One more fix to OSP 18 jobs

### DIFF
--- a/znoyder/config.d/43-override-OSP-18.yml
+++ b/znoyder/config.d/43-override-OSP-18.yml
@@ -626,6 +626,7 @@ override:
         vars:
           extra_commands:
             - dnf install -y python3-placement python3-placement-tests python3-testresources python3-testscenarios
+            - cp -r {{ zuul.project.src_dir }} /tmp/python-osc-placement && pip install /tmp/python-osc-placement
 
   'python-oslo-cache':
     'osp-18.0':


### PR DESCRIPTION
Installs the python-osc-placement also system-wide, so the functional test that requires a shell to recognize the proper option in openstack client works.