### PR TITLE
Revert "Fix ceilometer / OSP 18"

### DIFF
--- a/znoyder/config.d/43-override-OSP-18.yml
+++ b/znoyder/config.d/43-override-OSP-18.yml
@@ -52,7 +52,6 @@ override:
           extra_commands:
             - dnf install -y python3-kazoo python3-oslotest python3-stestr python3-testscenarios
             - pip install -c https://opendev.org/openstack/requirements/raw/branch/stable/2023.1/upper-constraints.txt --ignore-installed os-win requests-aws confluent-kafka
-            - dnf remove -y libvirt-libs
 
   'cinder':
     'osp-18.0':


### PR DESCRIPTION
Turns out it may not be really needed in the end.
This reverts commit a0e616c5478d38c443d42d7994a4012e89a87a12.