### PR TITLE
Apply proper upper-contraints file to neutron OSP17.1 pep8 job

### DIFF
--- a/znoyder/config.d/42-override-OSP-17.yml
+++ b/znoyder/config.d/42-override-OSP-17.yml
@@ -313,6 +313,12 @@ override:
         vars:
           extra_commands:
             - dnf install -y python3-hacking python3-neutron-lib-tests
+      'osp-tox-pep8':
+        vars:
+          tox_environment:
+            # the following constrains file replaces upstream neutron-lib version
+            # 2.10.2 with 2.10.3, which is the proper value for downstream
+            TOX_CONSTRAINTS_FILE: 'https://file.emea.redhat.com/eolivare/workarounds/osp17.1-upper-constraints.txt'
 
   'nova':
     'osp-17.0':


### PR DESCRIPTION
The OSP17.1 neutron version requires a new version of neutron-lib. When pep8 is executed, it fails because the upstream wallaby constrainsts file sets neutron-lib version to 2.10.2. This patch fixes the problem by using an alternative file that sets neutron-lib version to 2.10.3.
NOTE: the wallaby constraints file will not change anymore at this stage of the project.