### PR TITLE
Add required project for Neutron / OSP 17.1

### DIFF
--- a/znoyder/browser.py
+++ b/znoyder/browser.py
@@ -113,13 +113,13 @@ def get_releases(**kwargs):
 
 
 def main(args) -> None:
-    if args.command == 'components':
+    if args.subcommand == 'components':
         results = get_components(**vars(args))
         default_output = ['name']
-    elif args.command == 'packages':
+    elif args.subcommand == 'packages':
         results = get_packages(**vars(args))
         default_output = ['osp-name', 'osp-distgit', 'osp-patches']
-    elif args.command == 'releases':
+    elif args.subcommand == 'releases':
         results = get_releases(**vars(args))
         default_output = ['ospinfo_tag_name', 'git_release_branch']
     else:

--- a/znoyder/cli.py
+++ b/znoyder/cli.py
@@ -103,7 +103,7 @@ class OverridenSubparserAction(_SubParsersAction):
 
 
 def extend_parser_browser(parser) -> None:
-    subparsers = parser.add_subparsers(dest='command', metavar='command')
+    subparsers = parser.add_subparsers(dest='subcommand', metavar='subcommand')
     subparsers.required = True
 
     common = ArgumentParser(add_help=False)
@@ -246,8 +246,8 @@ def process_arguments(argv=None) -> Namespace:
     shared_parser = ArgumentParser(add_help=False)
     shared_parser.add_argument(
         '--log-mode',
-        default="both",
-        choices={"file", "terminal", "both"},
+        default='both',
+        choices={'file', 'terminal', 'both'},
         help='Where to write the output, default is both'
     )
     shared_parser.add_argument(
@@ -264,15 +264,15 @@ def process_arguments(argv=None) -> Namespace:
     # argparse one would override the arguments from the main parser if they
     # were specified there but not in the subparser
     subparsers = parser.add_subparsers(action=OverridenSubparserAction)
-    parser.add_argument('options', nargs=REMAINDER,
-                        help='additional arguments to the selected command')
+    parser.add_argument('command', nargs=REMAINDER,
+                        help='Znoyder command with its additional arguments')
 
     for command_name, command_dict in COMMANDS.items():
         parser_command = subparsers.add_parser(command_name,
                                                parents=[shared_parser])
         parser_command.set_defaults(
             func=getattr(command_dict['module'], 'main'))
-        parser.epilog += "  {}:  {}\n".format(
+        parser.epilog += '  {}:  {}\n'.format(
             command_name, command_dict['help'])
         command_dict['extend_parser_func'](parser_command)
 

--- a/znoyder/config.d/42-override-OSP-17.yml
+++ b/znoyder/config.d/42-override-OSP-17.yml
@@ -313,6 +313,8 @@ override:
         vars:
           extra_commands:
             - dnf install -y python3-hacking python3-neutron-lib-tests
+          required-projects:
+            - python-neutron-lib
 
   'nova':
     'osp-17.0':

--- a/znoyder/generator.py
+++ b/znoyder/generator.py
@@ -201,6 +201,7 @@ def generate_projects_templates(projects_pipelines_dict: dict) -> None:
         )
 
         try:
+            LOG.info(f'Writing {config_dest}')
             templater.generate_zuul_project_template(
                 path=config_dest,
                 name=GENERATED_CONFIG_PREFIX + project_name,
@@ -219,6 +220,7 @@ def generate_projects_config(projects_pipelines_dict: dict) -> None:
         GENERATED_CONFIG_PREFIX + 'projects' + GENERATED_CONFIG_EXTENSION
     )
 
+    LOG.info(f'Writing {config_dest}')
     templater.generate_zuul_projects_config(
         path=config_dest,
         projects=projects,
@@ -234,6 +236,7 @@ def generate_resources_config(projects_pipelines_dict: dict) -> None:
         'osp-internal' + GENERATED_CONFIG_EXTENSION
     )
 
+    LOG.info(f'Writing {config_dest}')
     templater.generate_zuul_resources_config(
         path=config_dest,
         projects=projects,

--- a/znoyder/tests/test_browser.py
+++ b/znoyder/tests/test_browser.py
@@ -433,7 +433,7 @@ class TestMain(TestCase):
         args = Mock()
         print_call = builtins.print = Mock()
 
-        args.command = None
+        args.subcommand = None
         args.debug = False
         args.output = False
         args.header = False
@@ -442,7 +442,7 @@ class TestMain(TestCase):
 
         print_call.assert_not_called()
 
-    def test_components_command(self):
+    def test_components_subcommand(self):
         component = {'name': 'comp_1'}
 
         results = [component]
@@ -451,7 +451,7 @@ class TestMain(TestCase):
         print_call = builtins.print = Mock()
         components_call = znoyder.browser.get_components = Mock()
 
-        args.command = 'components'
+        args.subcommand = 'components'
         args.debug = False
         args.output = False
         args.header = False
@@ -462,7 +462,7 @@ class TestMain(TestCase):
 
         print_call.assert_called_with(component['name'])
 
-    def test_packages_command(self):
+    def test_packages_subcommand(self):
         package = {
             'osp-name': 'pack_1',
             'osp-distgit': 'git_1',
@@ -475,7 +475,7 @@ class TestMain(TestCase):
         print_call = builtins.print = Mock()
         packages_call = znoyder.browser.get_packages = Mock()
 
-        args.command = 'packages'
+        args.subcommand = 'packages'
         args.debug = False
         args.output = False
         args.header = False
@@ -493,7 +493,7 @@ class TestMain(TestCase):
             )
         )
 
-    def test_releases_command(self):
+    def test_releases_subcommand(self):
         release = {
             'ospinfo_tag_name': 'tag_1',
             'git_release_branch': 'branch_1'
@@ -505,7 +505,7 @@ class TestMain(TestCase):
         print_call = builtins.print = Mock()
         releases_call = znoyder.browser.get_releases = Mock()
 
-        args.command = 'releases'
+        args.subcommand = 'releases'
         args.debug = False
         args.output = False
         args.header = False
@@ -526,7 +526,7 @@ class TestMain(TestCase):
     def test_debug_mode(self, print_call):
         args = Mock()
 
-        args.command = None
+        args.subcommand = None
         args.debug = True
         args.output = False
         args.header = False
@@ -551,7 +551,7 @@ class TestMain(TestCase):
         print_call = builtins.print = Mock()
         components_call = znoyder.browser.get_components = Mock()
 
-        args.command = 'components'
+        args.subcommand = 'components'
         args.debug = False
         args.output = '%s,%s' % (output1, output2)
         args.header = False
@@ -571,7 +571,7 @@ class TestMain(TestCase):
         args = Mock()
         print_call = builtins.print = Mock()
 
-        args.command = None
+        args.subcommand = None
         args.debug = False
         args.output = '%s,%s' % (output1, output2)
         args.header = True

--- a/znoyder/tests/test_cli.py
+++ b/znoyder/tests/test_cli.py
@@ -42,7 +42,7 @@ class TestCli(TestCase):
     def test_browse_empty(self, mock_argpare_print):
         """Test parsing of znoyder browse arguments."""
         cmd = ["browse-osp"]
-        # this should fail, since browse-osp requires a command
+        # this should fail, since browse-osp requires a subcommand
         self.assertRaises(SystemExit, process_arguments, cmd)
 
     @patch('argparse.ArgumentParser._print_message')
@@ -50,7 +50,7 @@ class TestCli(TestCase):
         """Test parsing of znoyder browse arguments."""
         cmd = "browse-osp components".split()
         args = process_arguments(cmd)
-        self.assertEqual(args.command, "components")
+        self.assertEqual(args.subcommand, "components")
         self.assertFalse(args.debug)
 
     @patch('argparse.ArgumentParser._print_message')
@@ -59,7 +59,7 @@ class TestCli(TestCase):
         cmd = ["browse-osp", "packages", "--component",
                "network", "--tag", "osp-17.0", "--output", "osp-patches"]
         args = process_arguments(cmd)
-        self.assertEqual(args.command, "packages")
+        self.assertEqual(args.subcommand, "packages")
         self.assertFalse(args.debug)
         self.assertEqual(args.component, "network")
         self.assertEqual(args.tag, "osp-17.0")
@@ -70,7 +70,7 @@ class TestCli(TestCase):
         """Test parsing of znoyder browse arguments."""
         cmd = "browse-osp releases --debug".split()
         args = process_arguments(cmd)
-        self.assertEqual(args.command, "releases")
+        self.assertEqual(args.subcommand, "releases")
         self.assertTrue(args.debug)
 
     @patch('argparse.ArgumentParser._print_message')

--- a/znoyder/tests/test_generator.py
+++ b/znoyder/tests/test_generator.py
@@ -345,7 +345,19 @@ class TestGenerator(TestCase):
 
     @patch('znoyder.templater.generate_zuul_project_template')
     def test_generate_projects_templates(self, mock_templater):
-        generate_projects_templates(self.example_projects_pipelines_dict)
+        with self.assertLogs(LOG) as mock_log:
+            generate_projects_templates(self.example_projects_pipelines_dict)
+
+        expected_log = [
+            'INFO:znoyderLogger:Writing '
+            'files-generated/osp-internal-jobs/zuul.d/cre-project1.yaml',
+            'INFO:znoyderLogger:Writing '
+            'files-generated/osp-internal-jobs/zuul.d/cre-project2.yaml',
+            'INFO:znoyderLogger:Writing '
+            'files-generated/osp-internal-jobs/zuul.d/cre-project3.yaml',
+        ]
+        self.assertEqual(len(mock_log.records), 3)
+        self.assertEqual(mock_log.output, expected_log)
 
         self.assertEqual(mock_templater.call_count, 3)
         mock_templater.assert_any_call(
@@ -390,14 +402,24 @@ class TestGenerator(TestCase):
             generate_projects_templates(self.example_projects_pipelines_dict)
 
         expected_log = [
+            'INFO:znoyderLogger:Writing '
+            'files-generated/osp-internal-jobs/zuul.d/cre-project1.yaml',
             'ERROR:znoyderLogger:Problem processing project1',
         ]
-        self.assertEqual(len(mock_log.records), 1)
+        self.assertEqual(len(mock_log.records), 2)
         self.assertEqual(mock_log.output, expected_log)
 
     @patch('znoyder.templater.generate_zuul_projects_config')
     def test_generate_projects_config(self, mock_templater):
-        generate_projects_config(self.example_projects_pipelines_dict)
+        with self.assertLogs(LOG) as mock_log:
+            generate_projects_config(self.example_projects_pipelines_dict)
+
+        expected_log = [
+            'INFO:znoyderLogger:Writing '
+            'files-generated/osp-internal-jobs-config/zuul.d/cre-projects.yaml'
+        ]
+        self.assertEqual(len(mock_log.records), 1)
+        self.assertEqual(mock_log.output, expected_log)
 
         mock_templater.assert_called_once_with(
             path='files-generated/osp-internal-jobs-config/'
@@ -408,7 +430,15 @@ class TestGenerator(TestCase):
 
     @patch('znoyder.templater.generate_zuul_resources_config')
     def test_generate_resources_config(self, mock_templater):
-        generate_resources_config(self.example_projects_pipelines_dict)
+        with self.assertLogs(LOG) as mock_log:
+            generate_resources_config(self.example_projects_pipelines_dict)
+
+        expected_log = [
+            'INFO:znoyderLogger:Writing '
+            'files-generated/sf-config/resources/osp-internal.yaml'
+        ]
+        self.assertEqual(len(mock_log.records), 1)
+        self.assertEqual(mock_log.output, expected_log)
 
         mock_templater.assert_called_once_with(
             path='files-generated/sf-config/resources/osp-internal.yaml',


### PR DESCRIPTION
There was a feature backported downstream that requires
a newer version of Neutron-Lib project installed locally.
Thanks to tox-siblings role, we can install the version
of code for liniting specified as dependent repository.