### PR TITLE
Fix get_packages by osp-project to cover non-url strings

### DIFF
--- a/znoyder/browser.py
+++ b/znoyder/browser.py
@@ -74,10 +74,11 @@ def get_packages(**kwargs):
                     if kwargs.get('upstream') in str(package.get('upstream'))]
 
     for package in packages:
-        if package['osp-patches']:
-            repo_name = re.search(r'^(.*)\/(.*)$', package['osp-patches']).group(2)
-            # Remove suffix .git if exist in osp-patches repo
-            package['osp-project'] = re.sub(r'.git$', "", repo_name)
+        repo_name = re.search(r'^(.*)\/(.*)$', package['osp-patches']).group(2)
+        if repo_name.endswith('.git'):
+            repo_name = repo_name[:-4]  # drop the suffix
+        package['osp-project'] = repo_name
+
     if kwargs.get('osp_project'):
         packages = [package for package in packages
                     if kwargs.get('osp_project') == package.get('osp-project')]

--- a/znoyder/browser.py
+++ b/znoyder/browser.py
@@ -16,6 +16,8 @@
 #    under the License.
 #
 
+import re
+
 from pprint import PrettyPrinter
 from urllib.parse import urlparse
 
@@ -72,7 +74,10 @@ def get_packages(**kwargs):
                     if kwargs.get('upstream') in str(package.get('upstream'))]
 
     for package in packages:
-        package['osp-project'] = urlparse(package['osp-patches']).path[1:]
+        if package['osp-patches']:
+            repo_name = re.search(r'^(.*)\/(.*)$', package['osp-patches']).group(2)
+            # Remove suffix .git if exist in osp-patches repo
+            package['osp-project'] = re.sub(r'.git$', "", repo_name)
     if kwargs.get('osp_project'):
         packages = [package for package in packages
                     if kwargs.get('osp_project') == package.get('osp-project')]

--- a/znoyder/tests/test_browser.py
+++ b/znoyder/tests/test_browser.py
@@ -98,13 +98,13 @@ class TestComponents(TestCase):
 
 class TestGetPackages(TestCase):
     def test_no_args(self):
-        project = 'some/project'
+        project = 'project'
 
         packages = [
             {
                 'osp-name': 'pack_1',
                 'osp-project': '',
-                'osp-patches': 'http://localhost:8080/%s' % project
+                'osp-patches': 'http://localhost:8080/some/%s' % project
             }
         ]
 
@@ -222,7 +222,14 @@ class TestGetPackages(TestCase):
             'project': 'project_2',
         }
 
-        packages = [package1, package2]
+        package3 = {
+            'name': 'name_3',
+            'osp-name': 'pack_3',
+            'osp-patches': 'git@gitlab.com:eng/test/repo_name_3.git',
+            'project': 'project_3',
+        }
+
+        packages = [package1, package2, package3]
 
         info_call = znoyder.browser.get_distroinfo = Mock()
 
@@ -233,6 +240,11 @@ class TestGetPackages(TestCase):
         self.assertEqual(
             [package1],
             get_packages(osp_project=package1['osp-project'])
+        )
+
+        self.assertEqual(
+            [package3],
+            get_packages(osp_project='repo_name_3')
         )
 
     def test_search_by_project(self):


### PR DESCRIPTION
Currently, the urlparse lib is used to find the short repo name from the osp-patches string in distroinfo. This does not work for non-url based strings as `git@gitlab.com:eng/test/repo_name.git`.

This patch is moving to use regex instead of urlparse asuming that the repo name is the string after the last `/` and removing the `.git` if exists. This should cover all kind of strings that may be used in osp-patches field.

Note this is changing slightly the behavior for repos in namespaces. i.e. before this patch if osp-patches is `ssh://server.com/foo/bar`, osp-project would be `foo/bar`. After this patch, it is `bar`. This behavior matches the current usage of this parameter which is used to matcht zuul.project.short_name which points always to the last part, `bar` in the previous case. This has not been affecting in the past because the osp-patches used were not namespaced.