### PR TITLE
Use basename instead of regex

### DIFF
--- a/znoyder/browser.py
+++ b/znoyder/browser.py
@@ -16,7 +16,7 @@
 #    under the License.
 #
 
-import re
+import os.path
 
 from pprint import PrettyPrinter
 from urllib.parse import urlparse
@@ -74,7 +74,7 @@ def get_packages(**kwargs):
                     if kwargs.get('upstream') in str(package.get('upstream'))]
 
     for package in packages:
-        repo_name = re.search(r'^(.*)\/(.*)$', package['osp-patches']).group(2)
+        repo_name = os.path.basename(package['osp-patches'])
         if repo_name.endswith('.git'):
             repo_name = repo_name[:-4]  # drop the suffix
         package['osp-project'] = repo_name


### PR DESCRIPTION
It turns out that in some cases we have projects in ospinfo that have no downstream forks – in such cases, there is osp-patches key set to empty string and regular expression breaks. Also, the solution with regular expression may lead to ambiguity (is a/b/c matched as a+b/c or a/b+c?), hence we replace that with just basename from path.